### PR TITLE
Refactor/cicd migration

### DIFF
--- a/.github/workflows/fe-cd.yml
+++ b/.github/workflows/fe-cd.yml
@@ -1,7 +1,7 @@
 name: fe-cd
 
 on:
-  # push 이벤트 대신 fe-ci 워크플로우가 완료되었을 때 실행되도록 변경
+  # fe-ci 워크플로우가 완료되었을 때 실행
   workflow_run:
     workflows: ["fe-ci"]
     types:
@@ -14,18 +14,45 @@ jobs:
     runs-on: ubuntu-latest
     # CI 워크플로우가 '성공(success)'했을 때만 배포 실행
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    
+
     steps:
-      # 불필요했던 Checkout, Setup Node, 빌드 과정 모두 삭제
-      - name: Deploy to EC2 via SSH
-        uses: appleboy/ssh-action@v1.0.3
+      # CI에서 업로드한 빌드 결과물(dist/) 다운로드
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
         with:
-          host: ${{ secrets.EC2_HOST_FE }}
-          username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_SSH_KEY }}
-          script: |
-            cd /home/ubuntu/fe-app
-            git pull origin main
-            npm ci
-            npm run build
-            pm2 restart fe-app
+          name: fe-dist
+          path: dist/
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # AWS 자격증명 설정
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      # dist/ 를 S3 버킷에 동기화 (변경된 파일만 업로드)
+      - name: Sync dist to S3
+        run: |
+          aws s3 sync dist/ s3://${{ secrets.S3_BUCKET_NAME }}/ \
+            --delete \
+            --cache-control "public, max-age=31536000, immutable"
+
+      # index.html 은 캐시 무효화 (항상 최신 파일 제공)
+      - name: Set cache-control for index.html
+        run: |
+          aws s3 cp s3://${{ secrets.S3_BUCKET_NAME }}/index.html \
+            s3://${{ secrets.S3_BUCKET_NAME }}/index.html \
+            --metadata-directive REPLACE \
+            --cache-control "no-cache, no-store, must-revalidate" \
+            --content-type "text/html"
+
+      # CloudFront 캐시 무효화 (선택 사항 — CloudFront 미사용 시 삭제)
+      - name: Invalidate CloudFront cache
+        if: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID != '' }}
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} \
+            --paths "/*"

--- a/.github/workflows/fe-ci.yml
+++ b/.github/workflows/fe-ci.yml
@@ -44,3 +44,10 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: fe-dist
+          path: dist/
+          retention-days: 1

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,6 +7,10 @@ export default defineConfig({
   server: {
     port: 3000,
   },
+  build: {
+    outDir: "dist",    // fe-ci.yml artifact path, fe-cd.yml S3 sync path 와 일치
+    emptyOutDir: true, // 빌드 전 dist/ 초기화
+  },
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),


### PR DESCRIPTION
---
name: PR 템플릿
about: PR 생성 시 이 템플릿을 사용해 주세요.
title: ":emoji: [#issue] "
---
# PR: 프론트엔드 배포 파이프라인 최적화 (S3 정적 호스팅 이관)

## 작업 목적
기존 EC2 SSH 접속 및 원격 빌드 방식에서 AWS S3 정적 웹사이트 호스팅 방식으로 배포 파이프라인을 이관하여 배포 속도 개선 및 서버 리소스 비용을 절감합니다.

##  주요 변경 사항

### 1. CI 워크플로우 개선 (`.github/workflows/fe-ci.yml`)
- **빌드 아티팩트 보관**: 빌드 결과물(`dist/`)을 `actions/upload-artifact@v4`를 사용해 업로드하도록 수정하였습니다.
- **연속성 확보**: CD 워크플로우에서 해당 아티팩트를 내려받아 배포에 사용할 수 있도록 아티팩트 이름을 `fe-dist`로 지정했습니다.

### 2. CD 워크플로우 전면 개편 (`.github/workflows/fe-cd.yml`)
- **배포 방식 변경**: EC2 SSH 접속 후 git pull/build 방식에서 AWS CLI를 통한 **S3 Sync** 방식으로 변경했습니다.
- **캐시 최적화**:
  - 일반 에셋: `max-age=31536000` (1년) 및 `immutable` 설정으로 브라우저 캐시 극대화.
  - `index.html`: `no-cache` 설정을 통해 사용자가 항상 최신 배포본을 참조하도록 구성.
- **CloudFront 연동**: 배포 완료 시 자동으로 CloudFront 캐시 무효화(`invalidation`)를 실행하도록 구성했습니다 (Secret 설정 시 작동).

### 3. Vite 빌드 설정 명시 (`vite.config.ts`)
- 워크플로우와의 정렬을 위해 `build.outDir`을 `dist`로 명시하고, 빌드 전 디렉토리를 비우도록 `emptyOutDir: true` 설정을 추가했습니다.

## 변경된 배포 플로우
1. `main` 브랜치 Push/Merge
2. **fe-ci**: Lint → Test → Build → **Upload Artifact (dist/)**
3. **fe-cd** (CI 성공 시 실행): **Download Artifact** → **S3 Sync** → **Invalidate CloudFront**

## 필요한 GitHub Secrets
본 파이프라인 작동을 위해 다음 Secrets 등록이 필요합니다:
- `AWS_ACCESS_KEY_ID`: AWS IAM User 액세스 키
- `AWS_SECRET_ACCESS_KEY`: AWS IAM User 비밀 키
- `AWS_REGION`: AWS 리전 (예: `ap-northeast-2`)
- `S3_BUCKET_NAME`: 배포 대상 S3 버킷 명
- `CLOUDFRONT_DISTRIBUTION_ID`: (선택) CloudFront 배포 ID

## 관련 브랜치
- `refactor/cicd-migration`
